### PR TITLE
[PR] Fixing windows path sep error.

### DIFF
--- a/lib/rewrite-middleware.js
+++ b/lib/rewrite-middleware.js
@@ -1,3 +1,5 @@
+let path = require('path');
+
 let common = require('karma/lib/middleware/common');
 let minimatch = require('minimatch');
 
@@ -68,7 +70,9 @@ function createContextRewriteMiddleware(logger, fileList, emitter, injector) {
 		let upstreamProxy = injector.get('config.upstreamProxy');
 		let proxyPath = upstreamProxy ? upstreamProxy.path : '/';
 		
-		let reverseContextFile = files.served.find(file => file.originalPath === REVERSE_CONTEXT);
+		let reverseContextFile = files.served.find(file => {
+      return file.originalPath === REVERSE_CONTEXT || file.originalPath === REVERSE_CONTEXT.split(path.sep).join('/');
+		});
 		if (!reverseContextFile.isUrl) {
 			reverseContextFile = filePathToUrlPath(reverseContextFile.path, basePath, urlRoot, proxyPath);
 		} else {


### PR DESCRIPTION
Hi,
Your `karma-iframes` helps me a lot in testing my old-way syntax fron-tend code!!!
But I do not know if you are using *nix or Windows in developing this plugin.

My Windows machine met a error in path.sep
For example,

```js
let REVERSE_CONTEXT = require.resolve('../static/reverse-context.js');
// ==> file absolute path is 'D:\\path\\to\\js';

let reverseContextFile = files.served.find(file=> file.originalPath === REVERSE_CONTEXT );
// ==> file.originalPath is 'D:/path/to/js'
```

Then the matching result will be `undefined`.
In order able to run cross platform, I suggest to add the resolve solution like using `path.sep`.

Could you pls merge this PR or update by your own solution way?
~~Dont know if this repo is PR welcomed~~

Waiting for you update !!

Thanks & Best Regards