### PR TITLE
URI encode main test script file path; fixes crash on Windows when username contains non-URI characters

### DIFF
--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -23,9 +23,9 @@ function IFramePreprocessor(logger) {
 			// FIXME: This does not preserve the script order but inserts the script always at the end
 			.replace('%SCRIPTS%', `
 %SCRIPTS%
-<script type="text/javascript" src="${STATIC_PREFIX}${transformedFilePath}"></script>
+<script type="text/javascript" src="${STATIC_PREFIX}${encodeURI(transformedFilePath)}"></script>
 `);
-		
+
 		// Save the file contents to the temp dir for serving it later
 		fs.writeFile(`${TMP_STATIC_FILES_DIR}/${transformedFilePath}`, content, (err) => {
 			if(err) {

--- a/lib/serve-file-middleware.js
+++ b/lib/serve-file-middleware.js
@@ -14,9 +14,9 @@ function createStaticFileMiddleware(logger, injector) {
 		if(req.url.indexOf(STATIC_PREFIX) !== 0) {
 			return next();
 		}
-		
-		let file = `${TMP_STATIC_FILES_DIR}/${req._parsedUrl.pathname.substr(STATIC_PREFIX.length)}`;
-		
+
+		let file = `${TMP_STATIC_FILES_DIR}/${decodeURI(req._parsedUrl.pathname.substr(STATIC_PREFIX.length))}`;
+
 		log.debug(`Searching for file to ${req.url} in ${file}`);
 
 		fs.stat(file, (err, stats) => {


### PR DESCRIPTION
If you have a space in your username, then the test file saved for the iframe will have a space too. Chrome automatically URI encodes request paths, but since we don't decode before serving, it tries to look for the URI-encoded filename and fails as it is different to the non-encoded filename.

This PR:
- Ensures the path is URI encoded when requested (rather than relying on the browser failsafe)
- Ensures the path is URI decoded when served

I did also consider just adding spaces to the transformation regex, but I felt this way is more futureproof.